### PR TITLE
Hotfix/changing transit ip addressing

### DIFF
--- a/modules/azure/transit/firewalls/fortinet/fortinet_egress_init.tftpl
+++ b/modules/azure/transit/firewalls/fortinet/fortinet_egress_init.tftpl
@@ -16,12 +16,6 @@ config system accprofile
     next
 end
 config router static
-    edit 4
-        set dst 168.63.129.16 255.255.255.255
-        set gateway ${lan_gateway}
-        set device "port2"
-        set comment "To Azure Load Balancer"
-    next
     edit 5
         set dst 0.0.0.0 0.0.0.0
         set gateway ${wan_gateway}

--- a/modules/azure/transit/firewalls/fortinet/fortinet_init.tftpl
+++ b/modules/azure/transit/firewalls/fortinet/fortinet_init.tftpl
@@ -15,14 +15,6 @@ config system accprofile
         set netgrp read-write
     next
 end
-config router static
-    edit 4
-        set dst 168.63.129.16 255.255.255.255
-        set gateway ${lan_gateway}
-        set device "port2"
-        set comment "To Azure Load Balancer"
-    next
-end
 config system api-user
     edit aviatrix_controller
     set accprofile "admin-api"

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -33,7 +33,7 @@ def generateApiToken(remote_conn):
                 # discovered_key = formatted_output[3]
                 # logging.warning(discovered_key)
             api_key = {
-                "api_key": f"{formatted_output} AND {type(formatted_output)}"
+                "api_key": f"{formatted_output[3]} AND {formatted_output[3].split(' ')[-1]}"
             }
                 # json_key = json.dumps(test_output, indent=4)
             json_key = json.dumps(api_key, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -28,18 +28,17 @@ def generateApiToken(remote_conn):
         if output:
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
-            if len(formatted_output) >= 3:
+            # if len(formatted_output) >= 3:
                 # discovered_key = formatted_output[3].split()[-1]
-                discovered_key = formatted_output[3]
+                # discovered_key = formatted_output[3]
                 # logging.warning(discovered_key)
-                api_key = {
-                    "api_key": discovered_key
-                    # "api_key": f"{formatted_output}"
-                }
+            api_key = {
+                "api_key": f"{formatted_output} AND {type(formatted_output)}"
+            }
                 # json_key = json.dumps(test_output, indent=4)
-                json_key = json.dumps(api_key, indent=4)
-                print(json_key)
-                return api_key
+            json_key = json.dumps(api_key, indent=4)
+            print(json_key)
+            return api_key
     except KeyError as e:
         error = {"error": str(e)}
         json.dumps(error, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -27,17 +27,14 @@ def generateApiToken(remote_conn):
         if output:
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
-            if formatted_output:
-                test_output = {
-                    "api_key": f"{formatted_output}"
+            if len(formatted_output) >= 3:
+                api_key = {
+                    "api_key": formatted_output[3].split()[-1]
                 }
-                # api_key = {
-                #     "api_key": formatted_output[3].split()[-1]
-                # }
-                json_key = json.dumps(test_output, indent=4)
-                # json_key = json.dumps(api_key, indent=4)
+                # json_key = json.dumps(test_output, indent=4)
+                json_key = json.dumps(api_key, indent=4)
                 print(json_key)
-                # return api_key
+                return api_key
     except KeyError as e:
         error = {"error": str(e)}
         json.dumps(error, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -15,7 +15,7 @@ fortigate_password = input_json['fortigate_password']
 # fortigate_username = os.getenv('FORTIGATE_USERNAME')
 # fortigate_password = os.getenv('FORTIGATE_PASSWORD')
 
-sleepyTime = 0.5
+sleepyTime = 1
 receiveTime = 100000
 
 

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -29,7 +29,7 @@ def generateApiToken(remote_conn):
             formatted_output = decode_output.splitlines()
             if formatted_output:
                 test_output = {
-                    "test": f"{formatted_output}"
+                    "api_key": f"{formatted_output}"
                 }
                 # api_key = {
                 #     "api_key": formatted_output[3].split()[-1]

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -28,8 +28,9 @@ def generateApiToken(remote_conn):
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
             if len(formatted_output) >= 3:
+                discovered_key = formatted_output[3].split()[-1]
                 api_key = {
-                    "api_key": formatted_output[3].split()[-1]
+                    "api_key": discovered_key
                     # "api_key": f"{formatted_output}"
                 }
                 # json_key = json.dumps(test_output, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -12,10 +12,6 @@ fortigate_hostname = input_json['fortigate_hostname']
 fortigate_username = input_json['fortigate_username']
 fortigate_password = input_json['fortigate_password']
 
-# fortigate_hostname = os.getenv('FORTIGATE_HOSTNAME')
-# fortigate_username = os.getenv('FORTIGATE_USERNAME')
-# fortigate_password = os.getenv('FORTIGATE_PASSWORD')
-
 sleepyTime = 1
 receiveTime = 100000
 
@@ -30,15 +26,9 @@ def generateApiToken(remote_conn):
             formatted_output = decode_output.splitlines()
             for line in formatted_output:
                 if 'API key' in line:
-                    
-            # if len(formatted_output) >= 3:
-                # discovered_key = formatted_output[3].split()[-1]
-                # discovered_key = formatted_output[3]
-                # logging.warning(discovered_key)
                     api_key = {
                         "api_key": f"{line.split(' ')[-1]}"
                     }
-                # json_key = json.dumps(test_output, indent=4)
                     json_key = json.dumps(api_key, indent=4)
                     print(json_key)
                     return api_key

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import json
 import paramiko
@@ -9,6 +10,10 @@ input_json = json.loads(input)
 fortigate_hostname = input_json['fortigate_hostname']
 fortigate_username = input_json['fortigate_username']
 fortigate_password = input_json['fortigate_password']
+
+# fortigate_hostname = os.getenv('FORTIGATE_HOSTNAME')
+# fortigate_username = os.getenv('FORTIGATE_USERNAME')
+# fortigate_password = os.getenv('FORTIGATE_PASSWORD')
 
 sleepyTime = 0.5
 receiveTime = 100000
@@ -22,7 +27,6 @@ def generateApiToken(remote_conn):
         if output:
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
-            print(formatted_output)
             api_key = {
                 "api_key": formatted_output[3].split()[-1]
             }

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -28,12 +28,16 @@ def generateApiToken(remote_conn):
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
             if formatted_output:
-                api_key = {
-                    "api_key": formatted_output[3].split()[-1]
+                test_output = {
+                    "test": f"{formatted_output}"
                 }
-                json_key = json.dumps(api_key, indent=4)
+                # api_key = {
+                #     "api_key": formatted_output[3].split()[-1]
+                # }
+                json_key = json.dumps(test_output, indent=4)
+                # json_key = json.dumps(api_key, indent=4)
                 print(json_key)
-                return api_key
+                # return api_key
     except KeyError as e:
         error = {"error": str(e)}
         json.dumps(error, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -28,17 +28,22 @@ def generateApiToken(remote_conn):
         if output:
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
+            for line in formatted_output:
+                if 'API key' in line:
+                    
             # if len(formatted_output) >= 3:
                 # discovered_key = formatted_output[3].split()[-1]
                 # discovered_key = formatted_output[3]
                 # logging.warning(discovered_key)
-            api_key = {
-                "api_key": f"{formatted_output[3]} AND {formatted_output[3].split(' ')[-1]}"
-            }
+                    api_key = {
+                        "api_key": f"{line.split(' ')[-1]}"
+                    }
                 # json_key = json.dumps(test_output, indent=4)
-            json_key = json.dumps(api_key, indent=4)
-            print(json_key)
-            return api_key
+                    json_key = json.dumps(api_key, indent=4)
+                    print(json_key)
+                    return api_key
+                else:
+                    continue
     except KeyError as e:
         error = {"error": str(e)}
         json.dumps(error, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -3,6 +3,7 @@ import sys
 import json
 import paramiko
 import time
+import logging
 
 input = sys.stdin.read()
 input_json = json.loads(input)
@@ -30,6 +31,7 @@ def generateApiToken(remote_conn):
             if len(formatted_output) >= 3:
                 # discovered_key = formatted_output[3].split()[-1]
                 discovered_key = formatted_output[3]
+                logging.warning(discovered_key)
                 api_key = {
                     "api_key": discovered_key
                     # "api_key": f"{formatted_output}"

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -4,16 +4,16 @@ import json
 import paramiko
 import time
 
-# input = sys.stdin.read()
-# input_json = json.loads(input)
+input = sys.stdin.read()
+input_json = json.loads(input)
 
-# fortigate_hostname = input_json['fortigate_hostname']
-# fortigate_username = input_json['fortigate_username']
-# fortigate_password = input_json['fortigate_password']
+fortigate_hostname = input_json['fortigate_hostname']
+fortigate_username = input_json['fortigate_username']
+fortigate_password = input_json['fortigate_password']
 
-fortigate_hostname = os.getenv('FORTIGATE_HOSTNAME')
-fortigate_username = os.getenv('FORTIGATE_USERNAME')
-fortigate_password = os.getenv('FORTIGATE_PASSWORD')
+# fortigate_hostname = os.getenv('FORTIGATE_HOSTNAME')
+# fortigate_username = os.getenv('FORTIGATE_USERNAME')
+# fortigate_password = os.getenv('FORTIGATE_PASSWORD')
 
 sleepyTime = 1
 receiveTime = 100000

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -29,8 +29,8 @@ def generateApiToken(remote_conn):
             formatted_output = decode_output.splitlines()
             if len(formatted_output) >= 3:
                 api_key = {
-                    # "api_key": formatted_output[3].split()[-1]
-                    "api_key": f"{formatted_output}"
+                    "api_key": formatted_output[3].split()[-1]
+                    # "api_key": f"{formatted_output}"
                 }
                 # json_key = json.dumps(test_output, indent=4)
                 json_key = json.dumps(api_key, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -31,7 +31,7 @@ def generateApiToken(remote_conn):
             if len(formatted_output) >= 3:
                 # discovered_key = formatted_output[3].split()[-1]
                 discovered_key = formatted_output[3]
-                logging.warning(discovered_key)
+                # logging.warning(discovered_key)
                 api_key = {
                     "api_key": discovered_key
                     # "api_key": f"{formatted_output}"

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -4,16 +4,16 @@ import json
 import paramiko
 import time
 
-input = sys.stdin.read()
-input_json = json.loads(input)
+# input = sys.stdin.read()
+# input_json = json.loads(input)
 
-fortigate_hostname = input_json['fortigate_hostname']
-fortigate_username = input_json['fortigate_username']
-fortigate_password = input_json['fortigate_password']
+# fortigate_hostname = input_json['fortigate_hostname']
+# fortigate_username = input_json['fortigate_username']
+# fortigate_password = input_json['fortigate_password']
 
-# fortigate_hostname = os.getenv('FORTIGATE_HOSTNAME')
-# fortigate_username = os.getenv('FORTIGATE_USERNAME')
-# fortigate_password = os.getenv('FORTIGATE_PASSWORD')
+fortigate_hostname = os.getenv('FORTIGATE_HOSTNAME')
+fortigate_username = os.getenv('FORTIGATE_USERNAME')
+fortigate_password = os.getenv('FORTIGATE_PASSWORD')
 
 sleepyTime = 1
 receiveTime = 100000
@@ -28,7 +28,8 @@ def generateApiToken(remote_conn):
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
             if len(formatted_output) >= 3:
-                discovered_key = formatted_output[3].split()[-1]
+                # discovered_key = formatted_output[3].split()[-1]
+                discovered_key = formatted_output[3]
                 api_key = {
                     "api_key": discovered_key
                     # "api_key": f"{formatted_output}"

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -27,12 +27,13 @@ def generateApiToken(remote_conn):
         if output:
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
-            api_key = {
-                "api_key": formatted_output[3].split()[-1]
-            }
-            json_key = json.dumps(api_key, indent=4)
-            print(json_key)
-            return api_key
+            if formatted_output:
+                api_key = {
+                    "api_key": formatted_output[3].split()[-1]
+                }
+                json_key = json.dumps(api_key, indent=4)
+                print(json_key)
+                return api_key
     except KeyError as e:
         error = {"error": str(e)}
         json.dumps(error, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -29,7 +29,8 @@ def generateApiToken(remote_conn):
             formatted_output = decode_output.splitlines()
             if len(formatted_output) >= 3:
                 api_key = {
-                    "api_key": formatted_output[3].split()[-1]
+                    # "api_key": formatted_output[3].split()[-1]
+                    "api_key": f"{formatted_output}"
                 }
                 # json_key = json.dumps(test_output, indent=4)
                 json_key = json.dumps(api_key, indent=4)

--- a/modules/azure/transit/firewalls/fortinet/generate_api_token.py
+++ b/modules/azure/transit/firewalls/fortinet/generate_api_token.py
@@ -22,6 +22,7 @@ def generateApiToken(remote_conn):
         if output:
             decode_output = output.decode("utf-8")
             formatted_output = decode_output.splitlines()
+            print(formatted_output)
             api_key = {
                 "api_key": formatted_output[3].split()[-1]
             }

--- a/modules/azure/transit/main.tf
+++ b/modules/azure/transit/main.tf
@@ -265,20 +265,20 @@ data "external" "fortinet_bootstrap_1" {
   }
 }
 
-data "external" "fortinet_bootstrap_2" {
-  count = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
-  depends_on = [
-    aviatrix_firewall_instance.firewall_instance_2,
-    aviatrix_firenet.firenet,
-    aviatrix_firewall_instance_association.firewall_instance_association_2
-  ]
-  program = ["python", "${path.root}/firewalls/fortinet/generate_api_token.py"]
-  query = {
-    fortigate_hostname = "${aviatrix_firewall_instance.firewall_instance_2[0].public_ip}"
-    fortigate_username = "${var.firewall_username}"
-    fortigate_password = "${random_password.generate_firewall_secret[0].result}"
-  }
-}
+# data "external" "fortinet_bootstrap_2" {
+#   count = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
+#   depends_on = [
+#     aviatrix_firewall_instance.firewall_instance_2,
+#     aviatrix_firenet.firenet,
+#     aviatrix_firewall_instance_association.firewall_instance_association_2
+#   ]
+#   program = ["python", "${path.root}/firewalls/fortinet/generate_api_token.py"]
+#   query = {
+#     fortigate_hostname = "${aviatrix_firewall_instance.firewall_instance_2[0].public_ip}"
+#     fortigate_username = "${var.firewall_username}"
+#     fortigate_password = "${random_password.generate_firewall_secret[0].result}"
+#   }
+# }
 
 # Vendor Integration if firewall vendor is fortinet.
 # tflint-ignore: terraform_unused_declarations

--- a/modules/azure/transit/main.tf
+++ b/modules/azure/transit/main.tf
@@ -265,46 +265,41 @@ data "external" "fortinet_bootstrap_1" {
   }
 }
 
-# data "external" "fortinet_bootstrap_2" {
-#   count = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
-#   depends_on = [
-#     aviatrix_firewall_instance.firewall_instance_2,
-#     aviatrix_firenet.firenet,
-#     aviatrix_firewall_instance_association.firewall_instance_association_2
-#   ]
-#   program = ["python", "${path.root}/firewalls/fortinet/generate_api_token.py"]
-#   query = {
-#     fortigate_hostname = "${aviatrix_firewall_instance.firewall_instance_2[0].public_ip}"
-#     fortigate_username = "${var.firewall_username}"
-#     fortigate_password = "${random_password.generate_firewall_secret[0].result}"
-#   }
-# }
+data "external" "fortinet_bootstrap_2" {
+  count = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
+  depends_on = [
+    aviatrix_firewall_instance.firewall_instance_2,
+    aviatrix_firenet.firenet,
+    aviatrix_firewall_instance_association.firewall_instance_association_2
+  ]
+  program = ["python", "${path.root}/firewalls/fortinet/generate_api_token.py"]
+  query = {
+    fortigate_hostname = "${aviatrix_firewall_instance.firewall_instance_2[0].public_ip}"
+    fortigate_username = "${var.firewall_username}"
+    fortigate_password = "${random_password.generate_firewall_secret[0].result}"
+  }
+}
 
-# Vendor Integration if firewall vendor is fortinet.
 # tflint-ignore: terraform_unused_declarations
-# data "aviatrix_firenet_vendor_integration" "vendor_integration_1" {
-#   count         = var.firenet_enabled && local.is_fortinet ? 1 : 0
-#   vpc_id        = aviatrix_firewall_instance.firewall_instance_1[0].vpc_id
-#   instance_id   = aviatrix_firewall_instance.firewall_instance_1[0].instance_id
-#   vendor_type   = "Fortinet FortiGate"
-#   public_ip     = aviatrix_firewall_instance.firewall_instance_1[0].public_ip
-#   firewall_name = aviatrix_firewall_instance.firewall_instance_1[0].firewall_name
-#   api_token     = sensitive(data.external.fortinet_bootstrap_1[0].result.api_key)
-#   save          = true
-# }
+data "aviatrix_firenet_vendor_integration" "vendor_integration_1" {
+  count         = var.firenet_enabled && local.is_fortinet ? 1 : 0
+  vpc_id        = aviatrix_firewall_instance.firewall_instance_1[0].vpc_id
+  instance_id   = aviatrix_firewall_instance.firewall_instance_1[0].instance_id
+  vendor_type   = "Fortinet FortiGate"
+  public_ip     = aviatrix_firewall_instance.firewall_instance_1[0].public_ip
+  firewall_name = aviatrix_firewall_instance.firewall_instance_1[0].firewall_name
+  api_token     = sensitive(data.external.fortinet_bootstrap_1[0].result.api_key)
+  save          = true
+}
 
-# # tflint-ignore: terraform_unused_declarations
-# data "aviatrix_firenet_vendor_integration" "vendor_integration_2" {
-#   count         = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
-#   vpc_id        = aviatrix_firewall_instance.firewall_instance_2[0].vpc_id
-#   instance_id   = aviatrix_firewall_instance.firewall_instance_2[0].instance_id
-#   vendor_type   = "Fortinet FortiGate"
-#   public_ip     = aviatrix_firewall_instance.firewall_instance_2[0].public_ip
-#   firewall_name = aviatrix_firewall_instance.firewall_instance_2[0].firewall_name
-#   api_token     = sensitive(data.external.fortinet_bootstrap_2[0].result.api_key)
-#   save          = true
-# }
-
-output "name" {
-  value = data.external.fortinet_bootstrap_1[0].result.api_key
+# tflint-ignore: terraform_unused_declarations
+data "aviatrix_firenet_vendor_integration" "vendor_integration_2" {
+  count         = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
+  vpc_id        = aviatrix_firewall_instance.firewall_instance_2[0].vpc_id
+  instance_id   = aviatrix_firewall_instance.firewall_instance_2[0].instance_id
+  vendor_type   = "Fortinet FortiGate"
+  public_ip     = aviatrix_firewall_instance.firewall_instance_2[0].public_ip
+  firewall_name = aviatrix_firewall_instance.firewall_instance_2[0].firewall_name
+  api_token     = sensitive(data.external.fortinet_bootstrap_2[0].result.api_key)
+  save          = true
 }

--- a/modules/azure/transit/main.tf
+++ b/modules/azure/transit/main.tf
@@ -282,25 +282,29 @@ data "external" "fortinet_bootstrap_2" {
 
 # Vendor Integration if firewall vendor is fortinet.
 # tflint-ignore: terraform_unused_declarations
-data "aviatrix_firenet_vendor_integration" "vendor_integration_1" {
-  count         = var.firenet_enabled && local.is_fortinet ? 1 : 0
-  vpc_id        = aviatrix_firewall_instance.firewall_instance_1[0].vpc_id
-  instance_id   = aviatrix_firewall_instance.firewall_instance_1[0].instance_id
-  vendor_type   = "Fortinet FortiGate"
-  public_ip     = aviatrix_firewall_instance.firewall_instance_1[0].public_ip
-  firewall_name = aviatrix_firewall_instance.firewall_instance_1[0].firewall_name
-  api_token     = sensitive(data.external.fortinet_bootstrap_1[0].result.api_key)
-  save          = true
-}
+# data "aviatrix_firenet_vendor_integration" "vendor_integration_1" {
+#   count         = var.firenet_enabled && local.is_fortinet ? 1 : 0
+#   vpc_id        = aviatrix_firewall_instance.firewall_instance_1[0].vpc_id
+#   instance_id   = aviatrix_firewall_instance.firewall_instance_1[0].instance_id
+#   vendor_type   = "Fortinet FortiGate"
+#   public_ip     = aviatrix_firewall_instance.firewall_instance_1[0].public_ip
+#   firewall_name = aviatrix_firewall_instance.firewall_instance_1[0].firewall_name
+#   api_token     = sensitive(data.external.fortinet_bootstrap_1[0].result.api_key)
+#   save          = true
+# }
 
-# tflint-ignore: terraform_unused_declarations
-data "aviatrix_firenet_vendor_integration" "vendor_integration_2" {
-  count         = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
-  vpc_id        = aviatrix_firewall_instance.firewall_instance_2[0].vpc_id
-  instance_id   = aviatrix_firewall_instance.firewall_instance_2[0].instance_id
-  vendor_type   = "Fortinet FortiGate"
-  public_ip     = aviatrix_firewall_instance.firewall_instance_2[0].public_ip
-  firewall_name = aviatrix_firewall_instance.firewall_instance_2[0].firewall_name
-  api_token     = sensitive(data.external.fortinet_bootstrap_2[0].result.api_key)
-  save          = true
+# # tflint-ignore: terraform_unused_declarations
+# data "aviatrix_firenet_vendor_integration" "vendor_integration_2" {
+#   count         = var.firenet_enabled && local.is_fortinet && var.firewall_ha ? 1 : 0
+#   vpc_id        = aviatrix_firewall_instance.firewall_instance_2[0].vpc_id
+#   instance_id   = aviatrix_firewall_instance.firewall_instance_2[0].instance_id
+#   vendor_type   = "Fortinet FortiGate"
+#   public_ip     = aviatrix_firewall_instance.firewall_instance_2[0].public_ip
+#   firewall_name = aviatrix_firewall_instance.firewall_instance_2[0].firewall_name
+#   api_token     = sensitive(data.external.fortinet_bootstrap_2[0].result.api_key)
+#   save          = true
+# }
+
+output "name" {
+  value = data.external.fortinet_bootstrap_1[0].result.api_key
 }

--- a/modules/azure/transit/outputs.tf
+++ b/modules/azure/transit/outputs.tf
@@ -42,11 +42,11 @@ output "firewall_1_api_key" {
   # sensitive   = true
 }
 
-output "firewall_2_api_key" {
-  value       = var.firenet_enabled ? data.external.fortinet_bootstrap_2[0].result.api_key : null
-  description = "The API Key for fortinet firewall 2."
-  # sensitive   = true
-}
+# output "firewall_2_api_key" {
+#   value       = var.firenet_enabled ? data.external.fortinet_bootstrap_2[0].result.api_key : null
+#   description = "The API Key for fortinet firewall 2."
+#   # sensitive   = true
+# }
 
 output "firenet_enabled" {
   description = "Outputs true if firenet is enabled, used to auto add spokes to firewall policy for inspection"

--- a/modules/azure/transit/outputs.tf
+++ b/modules/azure/transit/outputs.tf
@@ -39,13 +39,13 @@ output "firewall_password" {
 output "firewall_1_api_key" {
   value       = var.firenet_enabled ? data.external.fortinet_bootstrap_1[0].result.api_key : null
   description = "The API Key for fortinet firewall 1."
-  sensitive   = true
+  # sensitive   = true
 }
 
 output "firewall_2_api_key" {
   value       = var.firenet_enabled ? data.external.fortinet_bootstrap_2[0].result.api_key : null
   description = "The API Key for fortinet firewall 2."
-  sensitive   = true
+  # sensitive   = true
 }
 
 output "firenet_enabled" {

--- a/modules/azure/transit/outputs.tf
+++ b/modules/azure/transit/outputs.tf
@@ -39,14 +39,14 @@ output "firewall_password" {
 output "firewall_1_api_key" {
   value       = var.firenet_enabled ? data.external.fortinet_bootstrap_1[0].result.api_key : null
   description = "The API Key for fortinet firewall 1."
-  # sensitive   = true
+  sensitive   = true
 }
 
-# output "firewall_2_api_key" {
-#   value       = var.firenet_enabled ? data.external.fortinet_bootstrap_2[0].result.api_key : null
-#   description = "The API Key for fortinet firewall 2."
-#   # sensitive   = true
-# }
+output "firewall_2_api_key" {
+  value       = var.firenet_enabled ? data.external.fortinet_bootstrap_2[0].result.api_key : null
+  description = "The API Key for fortinet firewall 2."
+  sensitive   = true
+}
 
 output "firenet_enabled" {
   description = "Outputs true if firenet is enabled, used to auto add spokes to firewall policy for inspection"

--- a/modules/azure/transit/variables.tf
+++ b/modules/azure/transit/variables.tf
@@ -175,6 +175,6 @@ locals {
   firewall_subnet            = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, 0)
   firewall_lan_gateway_subnet = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, 1)
   firewall_wan_gateway       = cidrhost(local.firewall_subnet, 1)
-  fortinet_bootstrap         = local.is_fortinet && var.egress_enabled ? templatefile("${path.module}/firewalls/fortinet/fortinet_egress_init.tftpl", { lan_gateway = local.firewall_lan_gateway, wan_gateway = local.firewall_wan_gateway }) : templatefile("${path.module}/firewalls/fortinet/fortinet_init.tftpl", { lan_gateway = local.firewall_lan_gateway })
+  fortinet_bootstrap         = local.is_fortinet && var.egress_enabled ? templatefile("${path.module}/firewalls/fortinet/fortinet_egress_init.tftpl", { wan_gateway = local.firewall_wan_gateway }) : templatefile("${path.module}/firewalls/fortinet/fortinet_init.tftpl")
 
 }

--- a/modules/azure/transit/variables.tf
+++ b/modules/azure/transit/variables.tf
@@ -170,15 +170,10 @@ locals {
   transit_gateway_newbits    = var.insane_mode ? 26 - local.cidrbits : 28 - local.cidrbits
   netnum                     = pow(2, local.transit_gateway_newbits)
   firewall_newbits           = 28 - local.cidrbits
-  # primary_newbits            = var.primary_subnet_size - local.cidrbits
-  # secondary_newbits          = var.secondary_ha_subnet_size - local.cidrbits
-  # subnets                    = var.insane_mode ? cidrsubnets(var.vnet_address_prefix, local.firewall_newbits, local.primary_newbits, local.secondary_newbits, local.transit_gateway_newbits, local.transit_gateway_newbits) : cidrsubnets(var.vnet_address_prefix, local.transit_gateway_newbits, local.transit_gateway_newbits, local.firewall_newbits, local.primary_newbits, local.secondary_newbits)
   transit_gateway_subnet     = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, local.netnum - 2)
   transit_gateway_ha_subnet  = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, local.netnum - 1)
   firewall_subnet            = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, 0)
   firewall_lan_gateway_subnet = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, 1)
-  # firewall_lan_gateway       = cidrhost(local.subnets[4], 1)
-  firewall_lan_gateway       = cidrhost(local.firewall_lan_gateway_subnet,1)
   firewall_wan_gateway       = cidrhost(local.firewall_subnet, 1)
   fortinet_bootstrap         = local.is_fortinet && var.egress_enabled ? templatefile("${path.module}/firewalls/fortinet/fortinet_egress_init.tftpl", { lan_gateway = local.firewall_lan_gateway, wan_gateway = local.firewall_wan_gateway }) : templatefile("${path.module}/firewalls/fortinet/fortinet_init.tftpl", { lan_gateway = local.firewall_lan_gateway })
 

--- a/modules/azure/transit/variables.tf
+++ b/modules/azure/transit/variables.tf
@@ -168,16 +168,18 @@ locals {
   is_fortinet                = length(regexall("fortinet", lower(var.firewall_image))) > 0 # Check if fw image contains fortinet.
   cidrbits                   = tonumber(split("/", var.vnet_address_prefix)[1])
   transit_gateway_newbits    = var.insane_mode ? 26 - local.cidrbits : 28 - local.cidrbits
-  transit_gateway_ha_newbits = var.insane_mode ? 26 - local.cidrbits : 28 - local.cidrbits
+  netnum                     = pow(2, local.transit_gateway_newbits)
   firewall_newbits           = 28 - local.cidrbits
-  primary_newbits            = var.primary_subnet_size - local.cidrbits
-  secondary_newbits          = var.secondary_ha_subnet_size - local.cidrbits
-  subnets                    = cidrsubnets(var.vnet_address_prefix, local.transit_gateway_newbits, local.transit_gateway_ha_newbits, local.firewall_newbits, local.primary_newbits, local.secondary_newbits)
-  transit_gateway_subnet     = local.subnets[0]
-  transit_gateway_ha_subnet  = local.subnets[1]
-  firewall_subnet            = local.subnets[2]
-  firewall_lan_gateway       = cidrhost(local.subnets[4], 1)
+  # primary_newbits            = var.primary_subnet_size - local.cidrbits
+  # secondary_newbits          = var.secondary_ha_subnet_size - local.cidrbits
+  # subnets                    = var.insane_mode ? cidrsubnets(var.vnet_address_prefix, local.firewall_newbits, local.primary_newbits, local.secondary_newbits, local.transit_gateway_newbits, local.transit_gateway_newbits) : cidrsubnets(var.vnet_address_prefix, local.transit_gateway_newbits, local.transit_gateway_newbits, local.firewall_newbits, local.primary_newbits, local.secondary_newbits)
+  transit_gateway_subnet     = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, local.netnum - 2)
+  transit_gateway_ha_subnet  = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, local.netnum - 1)
+  firewall_subnet            = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, 0)
+  firewall_lan_gateway_subnet = cidrsubnet(var.vnet_address_prefix, local.transit_gateway_newbits, 1)
+  # firewall_lan_gateway       = cidrhost(local.subnets[4], 1)
+  firewall_lan_gateway       = cidrhost(local.firewall_lan_gateway_subnet,1)
   firewall_wan_gateway       = cidrhost(local.firewall_subnet, 1)
   fortinet_bootstrap         = local.is_fortinet && var.egress_enabled ? templatefile("${path.module}/firewalls/fortinet/fortinet_egress_init.tftpl", { lan_gateway = local.firewall_lan_gateway, wan_gateway = local.firewall_wan_gateway }) : templatefile("${path.module}/firewalls/fortinet/fortinet_init.tftpl", { lan_gateway = local.firewall_lan_gateway })
-}
 
+}


### PR DESCRIPTION
- Changed Transit Gateway IP Addressing to use the last two subnets in a network
- removed loadbalancer static route from fortinet bootstrap; this automatic now from aviatrix vendor integration.
- Updated python script to more accurately retrieve API Token from fortinet